### PR TITLE
Fixed relative font position issue

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -232,6 +232,7 @@ module.exports = {
             // by webpacks internal loaders.
             exclude: [/\.(js|jsx|mjs)$/, /\.html$/, /\.json$/],
             options: {
+              publicPath: '../media/',
               name: "static/media/[name].[hash:8].[ext]"
             }
           }


### PR DESCRIPTION
The above fix - means that webpack will use a relative path for the fonts.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
