### PR TITLE
Pick up fix in tailwind-config to ensure that audience builder CSS doesn't get purged.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swrve/react-scripts",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@svgr/webpack": "4.3.3",
-    "@swrve/tailwind-config": "0.18.3",
+    "@swrve/tailwind-config": "0.18.4",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "babel-eslint": "10.1.0",


### PR DESCRIPTION
Bump @swrve/tailwind-config to 0.18.4 to pick up fix to ensure that audience builder CSS doesn't get purged.

@stevenfitzpatrick 

https://swrvedev.jira.com/browse/SWRVE-26519